### PR TITLE
simplify installation

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -41,9 +41,10 @@ my $build = $class->new(
     ],
 
     build_requires     => { 'ExtUtils::CBuilder' => 0, },
-    test_requires      => { 'Test::Fake::HTTPD', => 0, 'Test::Differences' => 0, 'Test::Exception' => 0, 'Test::Output' => 0, },
     configure_requires => { 'Module::Build'      => 0.42 },
+    test_requires      => { 'Test::Differences'  => 0, 'Test::Exception' => 0, 'Test::Output' => 0, },
     requires           => { 'perl'               => '5.008' },
+    recommends         => { 'Test::Fake::HTTPD'  => 0, },
     meta_merge         => {
         'resources' => {
             'repository' => 'https://github.com/Ensembl/Bio-DB-Big',

--- a/Build.PL
+++ b/Build.PL
@@ -41,8 +41,8 @@ my $build = $class->new(
     ],
 
     build_requires     => { 'ExtUtils::CBuilder' => 0, },
-    configure_requires => { 'Module::Build'      => 0.42, 'Module::Build::Pluggable' => 0, 'Module::Build::Pluggable::CPANfile' => 0, },
     test_requires      => { 'Test::Fake::HTTPD', => 0, 'Test::Differences' => 0, 'Test::Exception' => 0, 'Test::Output' => 0, },
+    configure_requires => { 'Module::Build'      => 0.42 },
     requires           => { 'perl'               => '5.008' },
     meta_merge         => {
         'resources' => {

--- a/t/05remote.t
+++ b/t/05remote.t
@@ -20,8 +20,12 @@ use strict;
 use warnings;
 
 use Test::More;
-use Test::Fake::HTTPD;
 use Test::Output;
+BEGIN {
+	if (not eval {require Test::Fake::HTTPD; 1;}) {
+		plan skip_all => 'Optional module Test::Fake::HTTPD not available';
+	}
+}
 use Test::Exception;
 use Bio::DB::Big;
 


### PR DESCRIPTION
On a recent fresh installation, this brought along 41 (!!!) additional modules: 15 specified from Build configure that are not actually needed, and 26 for fake remote testing, which is nice but not essential and sometimes fails anyway. This makes remote testing optional and only runs test 5 if Test::Fake::HTTPD is already installed.